### PR TITLE
bump build image version

### DIFF
--- a/Dockerfile-cloak-server
+++ b/Dockerfile-cloak-server
@@ -1,4 +1,4 @@
-FROM golang:1.17.9-alpine3.15 AS build
+FROM golang:1.22.5-alpine3.20 AS build
 
 WORKDIR /opt
 RUN apk add git make
@@ -9,20 +9,20 @@ RUN go get ./...
 RUN make
 
 
-# Final Docker image 
+# Final Docker image
 FROM alpine:latest
 
 RUN apk upgrade \
     && apk add tzdata \
     && rm -rf /var/cache/apk/*
-    
+
 ENV LOCAL_IP     127.0.0.1
 ENV LOCAL_PORT   8399
 ENV METHOD       shadowsocks
 ENV BYPASSUID    null
 ENV REDIRADDR    1.0.0.1
 ENV PRIVATEKEY   null
-ENV ADMINUID     null 
+ENV ADMINUID     null
 ENV PUBLICKEY    null
 ENV ENCRYPTION   AEAD_CHACHA20_POLY1305
 ENV PASSWORD     null


### PR DESCRIPTION
Bumped the golang image version to accommodate changes in https://github.com/cbeuw/Cloak
In addition to the Dockerfile changes in this PR, the new image should be built and pushed, and the docker-compose altered if necessary