### PR TITLE
Update Dockerfile-cloak-server

### DIFF
--- a/Dockerfile-cloak-server
+++ b/Dockerfile-cloak-server
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-alpine3.20 AS build
+FROM golang:1.24.3-alpine3.21 AS build
 
 WORKDIR /opt
 RUN apk add git make


### PR DESCRIPTION
Altered dockerfile to reflect changes in golang version in original cloak by cbeuw (https://github.com/cbeuw/Cloak) - See go.mod

Otherwize - docker container of cloak can't build